### PR TITLE
Deprecated method(DrawSphere) changes SphereHandleCap

### DIFF
--- a/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/.gitignore
+++ b/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/contentModel.xml
+/modules.xml
+/.idea.Include.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/encodings.xml
+++ b/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/indexLayout.xml
+++ b/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/vcs.xml
+++ b/Pivot Editor/Include/.idea/.idea.Include.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/Pivot Editor/Include/PivotEditor_EditorMethods.cs
+++ b/Pivot Editor/Include/PivotEditor_EditorMethods.cs
@@ -450,7 +450,14 @@ namespace Rito.EditorUtilities
             private void DrawPivotPointGizmo()
             {
                 Handles.color = HandleColor;
-                Handles.DrawSphere(0, me.pivotPos, Quaternion.identity, HandleUtility.GetHandleSize(me.pivotPos) * 0.12f);
+                // Handles.DrawSphere(0, me.pivotPos, Quaternion.identity, HandleUtility.GetHandleSize(me.pivotPos) * 0.12f);
+                Handles.SphereHandleCap(
+                0,
+                me.pivotPos,
+                Quaternion.identity,
+                HandleUtility.GetHandleSize(me.pivotPos) * 0.12f,
+                EventType.Repaint
+                );
             }
 
             private void DrawPivotHandle()


### PR DESCRIPTION
유니티 2021버전에서 안되길래 검색해서 고쳐봤습니다